### PR TITLE
Add a stable public interface for accessing the data underlying a `BenchmarkResult`

### DIFF
--- a/src/BLASBenchmarksCPU.jl
+++ b/src/BLASBenchmarksCPU.jl
@@ -20,11 +20,27 @@ using BenchmarkTools, ProgressMeter
 # Plotting & presenting results
 using VegaLite, DataFrames
 
+export benchmark_result_type
+export benchmark_result_df
+export benchmark_result_threaded
+export logspace
+export plot
+export runbench
 
-export runbench, logspace, plot, matmul!,
-    gemmmkl!, mkl_set_num_threads,
-    gemmopenblas!, openblas_set_num_threads,
-    gemmblis!, blis_set_num_threads
+# BLIS
+export gemmblis!
+export blis_set_num_threads
+
+# Octavian.jl
+export matmul!
+
+# OpenBLAS
+export gemmopenblas!
+export openblas_set_num_threads
+
+# MKL
+export gemmmkl!
+export mkl_set_num_threads
 
 # set threads
 const libMKL = MKL_jll.libmkl_rt # more convenient name

--- a/src/runbenchmark.jl
+++ b/src/runbenchmark.jl
@@ -1,10 +1,31 @@
-
 struct BenchmarkResult{T}
     df::DataFrame
     threaded::Bool
 end
+
+"""
+    benchmark_result_type(benchmark_result::BenchmarkResult)
+"""
+function benchmark_result_type(::BenchmarkResult{T}) where {T}
+    return T
+end
+
+"""
+    benchmark_result_df(benchmark_result::BenchmarkResult)
+"""
+function benchmark_result_df(benchmark_result::BenchmarkResult)
+    return deepcopy(benchmark_result.df)
+end
+
+"""
+    benchmark_result_threaded(benchmark_result::BenchmarkResult)
+"""
+function benchmark_result_threaded(benchmark_result::BenchmarkResult)
+    return benchmark_result.threaded
+end
+
 function Base.show(io::IO, br::BenchmarkResult{T}) where {T}
-    println(io, "Bennchmark Result of Matrix{$T}, threads = $(br.threaded)")
+    println(io, "Bennchmark Result of Matrix{$T}, threaded = $(br.threaded)")
     println(io, br.df)
 end
 


### PR DESCRIPTION
Fixes https://github.com/chriselrod/BLASBenchmarks.jl/issues/8

The idea here is that we add a stable public interface for getting the raw data inside a `BenchmarkResult`. Then users can just take that raw data and use whatever plotting package they want.