### PR TITLE
Revert "CompatHelper: bump compat for "VectorizationBase" to "0.16""

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ LoopVectorization = "0.9, 0.10"
 Octavian = "0.2"
 ProgressMeter = "1.4"
 Tullio = "0.2"
-VectorizationBase = "0.15, 0.16"
+VectorizationBase = "0.15"
 VegaLite = "2.3"
 julia = "1.5"
 


### PR DESCRIPTION
Reverts chriselrod/BLASBenchmarksCPU.jl#29