### PR TITLE
Calculate 5 summaries while running benchmarks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BLASBenchmarksCPU"
 uuid = "5fdc822c-4560-4d20-af7e-e5ee461714d5"
 authors = ["Chris Elrod <elrodc@gmail.com> and contributors"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -121,6 +121,7 @@ function _plot(
         )
         push!(plt, l)
     end
+    display(plt)
     mkpath(plot_directory)
     _filenames = String[]
     extension_dict = Dict("svg" => SVG, "png" => PNG, "pdf" => PDF, "ps" => PS)

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -10,7 +10,7 @@ Defines the mapping between libraries and colors
 # make sure colors are distinguishable against white background by adding white to the seed list,
 # then deleting it from the resultant palette
 palette = distinguishable_colors(length(LIBRARIES) + 2, [colorant"white", colorant"black", colorant"#66023C", colorant"#0071c5"])
-deleteat!(palette, 1); deleteat!(palette, 2)
+deleteat!(palette, 1); deleteat!(palette, 1)
 const COLOR_MAP = Dict(zip(LIBRARIES, palette))
 getcolor(l::Symbol) = COLOR_MAP[l]
 for (alias,ref) ∈ [(:BLIS,:blis),(:generic,:Generic),(:GENERIC,:Generic)]
@@ -79,7 +79,8 @@ end
          measure = :minimum,
          plot_directory = default_plot_directory(),
          plot_filename = default_plot_filename(br; desc = desc, logscale = logscale),
-         file_extensions = ["svg", "png"])
+         file_extensions = ["svg", "png"],
+         displayplot = true)
 
 `measure` refers to the BenchmarkTools summary on times. Valid options are:
 `:minimum`, `:medain`, `:mean`, `:maximum`, and `:hmean`.
@@ -103,6 +104,7 @@ function _plot(
     plot_directory::AbstractString = default_plot_directory(),
     plot_filename::AbstractString = default_plot_filename(br; desc = desc, logscale = logscale),
     file_extensions = ["svg", "png"],
+    displayplot = true
 ) where {T}
     j = get_measure_index(measure) # throw early if `measure` invalid
     colors = getcolor.(br.libraries);
@@ -121,7 +123,7 @@ function _plot(
         )
         push!(plt, l)
     end
-    display(plt)
+    displayplot && display(plt)
     mkpath(plot_directory)
     _filenames = String[]
     extension_dict = Dict("svg" => SVG, "png" => PNG, "pdf" => PDF, "ps" => PS)

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -3,11 +3,30 @@ import BLASBenchmarksCPU
 import StatsPlots
 @testset "Interface" begin
     benchmark_result = BLASBenchmarksCPU.runbench(Float64; sizes = [1, 2, 5, 10, 20, 50, 100, 200], threaded=false, summarystat = BLASBenchmarksCPU.median) #test that threads=false at least doesn't throw somewhere.
-    df = BLASBenchmarksCPU.benchmark_result_df(benchmark_result)
-    @test df isa BLASBenchmarksCPU.DataFrame
-    df[!, :Size] = Float64.(df[!, :Size]);
-    df[!, :GFLOPS] = Float64.(df[!, :GFLOPS]);
-    df[!, :Seconds] = Float64.(df[!, :Seconds]);
-    p = StatsPlots.@df df StatsPlots.plot(:Size, :GFLOPS; group = :Library, legend = :bottomright)
-    @test p isa StatsPlots.Plots.Plot
+    dfmin = BLASBenchmarksCPU.benchmark_result_df(benchmark_result) # minimum
+    dfmedian = BLASBenchmarksCPU.benchmark_result_df(benchmark_result, :median)
+    dfmean = BLASBenchmarksCPU.benchmark_result_df(benchmark_result, :mean)
+    dfmax = BLASBenchmarksCPU.benchmark_result_df(benchmark_result, :maximum)
+    @test_throws ArgumentError  BLASBenchmarksCPU.benchmark_result_df(benchmark_result, :foobar)
+    @test dfmin isa BLASBenchmarksCPU.DataFrame
+    @test dfmedian isa BLASBenchmarksCPU.DataFrame
+    @test dfmean isa BLASBenchmarksCPU.DataFrame
+    @test dfmax isa BLASBenchmarksCPU.DataFrame
+    for df ∈ (dfmin,dfmedian,dfmean,dfmax)
+        df[!, :Size] = Float64.(df[!, :Size]);
+        df[!, :GFLOPS] = Float64.(df[!, :GFLOPS]);
+        df[!, :Seconds] = Float64.(df[!, :Seconds]);
+        p = StatsPlots.@df df StatsPlots.plot(:Size, :GFLOPS; group = :Library, legend = :bottomright)
+        @test p isa StatsPlots.Plots.Plot
+    end
+    @test all(dfmin[!, :GFLOPS] .≥ dfmedian[!, :GFLOPS])
+    @test all(dfmin[!, :GFLOPS] .≥ dfmean[!, :GFLOPS])
+    @test all(dfmin[!, :GFLOPS] .≥ dfmax[!, :GFLOPS])
+    @test any(dfmin[!, :GFLOPS] .≠ dfmedian[!, :GFLOPS])
+    @test any(dfmin[!, :GFLOPS] .≠ dfmean[!, :GFLOPS])
+    @test any(dfmin[!, :GFLOPS] .≠ dfmax[!, :GFLOPS])
+    @test any(dfmedian[!, :GFLOPS] .≥ dfmax[!, :GFLOPS])
+    @test any(dfmean[!, :GFLOPS] .≥ dfmax[!, :GFLOPS])
+    @test any(dfmedian[!, :GFLOPS] .≠ dfmax[!, :GFLOPS])
+    @test any(dfmean[!, :GFLOPS] .≠ dfmax[!, :GFLOPS])
 end

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -2,7 +2,7 @@
 import BLASBenchmarksCPU
 import StatsPlots
 @testset "Interface" begin
-    benchmark_result = BLASBenchmarksCPU.runbench(Float64; sizes = [1, 2, 5, 10, 20, 50, 100, 200], threaded=false, summarystat = BLASBenchmarksCPU.median) #test that threads=false at least doesn't throw somewhere.
+    benchmark_result = BLASBenchmarksCPU.runbench(Float64; sizes = [1, 2, 5, 10, 20, 50, 100, 200], threaded=false) #test that threads=false at least doesn't throw somewhere.
     dfmin = BLASBenchmarksCPU.benchmark_result_df(benchmark_result) # minimum
     dfmedian = BLASBenchmarksCPU.benchmark_result_df(benchmark_result, :median)
     dfmean = BLASBenchmarksCPU.benchmark_result_df(benchmark_result, :mean)

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -2,7 +2,7 @@
 import BLASBenchmarksCPU
 import StatsPlots
 @testset "Interface" begin
-    benchmark_result = BLASBenchmarksCPU.runbench(Float64; sizes = [1, 2, 5, 10, 20, 50, 100, 200], threaded=false) #test that threads=false at least doesn't throw somewhere.
+    benchmark_result = BLASBenchmarksCPU.runbench(Float64; sizes = [1, 2, 5, 10, 20, 50, 100, 200], threaded=false, summarystat = BLASBenchmarksCPU.median) #test that threads=false at least doesn't throw somewhere.
     df = BLASBenchmarksCPU.benchmark_result_df(benchmark_result)
     @test df isa BLASBenchmarksCPU.DataFrame
     df[!, :Size] = Float64.(df[!, :Size]);

--- a/test/main.jl
+++ b/test/main.jl
@@ -19,20 +19,24 @@ for T in [Float64, Float32]
     BLASBenchmarksCPU.plot(
         benchmark_result;
         plot_directory = plot_directory,
+        displayplot = false
     )
     BLASBenchmarksCPU.plot(
         benchmark_result;
         plot_directory = plot_directory,
-        measure = :median
+        measure = :median,
+        displayplot = false
     )
     BLASBenchmarksCPU.plot(
         benchmark_result;
         plot_directory = plot_directory,
-        measure = :mean
+        measure = :mean,
+        displayplot = false
     )
     BLASBenchmarksCPU.plot(
         benchmark_result;
         plot_directory = plot_directory,
-        measure = :maximum
+        measure = :maximum,
+        displayplot = false
     )
 end

--- a/test/main.jl
+++ b/test/main.jl
@@ -20,4 +20,19 @@ for T in [Float64, Float32]
         benchmark_result;
         plot_directory = plot_directory,
     )
+    BLASBenchmarksCPU.plot(
+        benchmark_result;
+        plot_directory = plot_directory,
+        measure = :median
+    )
+    BLASBenchmarksCPU.plot(
+        benchmark_result;
+        plot_directory = plot_directory,
+        measure = :mean
+    )
+    BLASBenchmarksCPU.plot(
+        benchmark_result;
+        plot_directory = plot_directory,
+        measure = :maximum
+    )
 end


### PR DESCRIPTION
Now you can specify which summary you want when calling `benchmark_result_df`:
```julia
julia> benchmark_result_df(rb)
18×4 DataFrame
 Row │ Size   Library   Seconds      GFLOPS
     │ Int64  String    Float64      Float64
─────┼──────────────────────────────────────────
   1 │    20  BLIS      4.29e-5        0.37296
   2 │    45  BLIS      4.5419e-5      4.01264
   3 │   100  BLIS      9.7717e-5     20.4673
   4 │    20  Gaius     2.62847e-7    60.8719
   5 │    45  Gaius     0.000264588    0.688807
   6 │   100  Gaius     5.9732e-5     33.4829
   7 │    20  MKL       4.40768e-7    36.3003
   8 │    45  MKL       2.47089e-6    73.7589
   9 │   100  MKL       5.46717e-6   365.82
  10 │    20  Octavian  2.39237e-7    66.8793
  11 │    45  Octavian  2.17778e-6    83.6862
  12 │   100  Octavian  4.73643e-6   422.259
  13 │    20  OpenBLAS  7.06423e-7    22.6493
  14 │    45  OpenBLAS  4.98383e-6    36.5682
  15 │   100  OpenBLAS  1.443e-5     138.6
  16 │    20  Tullio    2.6291e-7     60.8574
  17 │    45  Tullio    2.16711e-6    84.0981
  18 │   100  Tullio    0.000125153   15.9804

julia> benchmark_result_df(rb, :median)
18×4 DataFrame
 Row │ Size   Library   Seconds      GFLOPS
     │ Int64  String    Float64      Float64
─────┼──────────────────────────────────────────
   1 │    20  BLIS      4.71605e-5     0.339267
   2 │    45  BLIS      4.9872e-5      3.65436
   3 │   100  BLIS      0.000125569   15.9274
   4 │    20  Gaius     2.64962e-7    60.3861
   5 │    45  Gaius     0.000304132    0.599246
   6 │   100  Gaius     0.000279572    7.15381
   7 │    20  MKL       4.44111e-7    36.027
   8 │    45  MKL       2.50067e-6    72.8806
   9 │   100  MKL       5.87317e-6   340.532
  10 │    20  Octavian  2.40778e-7    66.4513
  11 │    45  Octavian  2.20433e-6    82.6781
  12 │   100  Octavian  4.83843e-6   413.357
  13 │    20  OpenBLAS  7.12453e-7    22.4576
  14 │    45  OpenBLAS  5.137e-6      35.4779
  15 │   100  OpenBLAS  1.5909e-5    125.715
  16 │    20  Tullio    2.63827e-7    60.6457
  17 │    45  Tullio    2.21511e-6    82.2758
  18 │   100  Tullio    0.000191986   10.4174
```
or plot
```julia
julia> plot(rb, measure=:median)
```
![image](https://user-images.githubusercontent.com/8043603/106177383-7278a600-6166-11eb-89dd-78415d218358.png)


As an aside, seems like `plot` should probably display the plot instead of just returning the files where it saves them. I added that as an option.